### PR TITLE
feat: Add localStorage persistence layer (closes #2)

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,28 @@
+const STORAGE_KEY = 'todo-app-todos';
+
+export function saveTodos(todos) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+  } catch {
+    // Silently fail (quota exceeded, private browsing, etc.)
+  }
+}
+
+export function loadTodos() {
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (data === null) return [];
+    const parsed = JSON.parse(data);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function clearTodos() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Silently fail
+  }
+}

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { saveTodos, loadTodos, clearTodos } from '../../src/storage.js';
+
+function makeTodo(overrides = {}) {
+  return {
+    id: 'test-1',
+    text: 'Test todo',
+    completed: false,
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function createMockStorage() {
+  const store = {};
+  return {
+    getItem: vi.fn((key) => (key in store ? store[key] : null)),
+    setItem: vi.fn((key, value) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createMockStorage());
+});
+
+describe('saveTodos', () => {
+  it('saves serialized todos to localStorage', () => {
+    const todos = [makeTodo()];
+    saveTodos(todos);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'todo-app-todos',
+      JSON.stringify(todos)
+    );
+  });
+
+  it('overwrites previously saved data', () => {
+    saveTodos([makeTodo({ text: 'First' })]);
+    saveTodos([makeTodo({ text: 'Second' })]);
+    expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(localStorage.setItem).toHaveBeenLastCalledWith(
+      'todo-app-todos',
+      JSON.stringify([makeTodo({ text: 'Second' })])
+    );
+  });
+});
+
+describe('loadTodos', () => {
+  it('loads and deserializes saved todos', () => {
+    const todos = [makeTodo(), makeTodo({ id: 'test-2', text: 'Another' })];
+    saveTodos(todos);
+    expect(loadTodos()).toEqual(todos);
+  });
+
+  it('returns [] when nothing saved (null)', () => {
+    expect(loadTodos()).toEqual([]);
+  });
+
+  it('returns [] for invalid JSON', () => {
+    localStorage.getItem = vi.fn(() => 'not json');
+    expect(loadTodos()).toEqual([]);
+  });
+
+  it('returns [] for non-array JSON (number)', () => {
+    localStorage.getItem = vi.fn(() => '42');
+    expect(loadTodos()).toEqual([]);
+  });
+
+  it('returns [] for non-array JSON (object)', () => {
+    localStorage.getItem = vi.fn(() => '{"key": "value"}');
+    expect(loadTodos()).toEqual([]);
+  });
+});
+
+describe('clearTodos', () => {
+  it('removes the key from localStorage', () => {
+    saveTodos([makeTodo()]);
+    clearTodos();
+    expect(localStorage.removeItem).toHaveBeenCalledWith('todo-app-todos');
+  });
+});
+
+describe('round-trip', () => {
+  it('save then load returns equivalent data', () => {
+    const todos = [
+      makeTodo(),
+      makeTodo({ id: 'test-2', text: 'Second', completed: true }),
+    ];
+    saveTodos(todos);
+    expect(loadTodos()).toEqual(todos);
+  });
+});
+
+describe('error handling', () => {
+  it('loadTodos returns [] if localStorage.getItem throws', () => {
+    localStorage.getItem = vi.fn(() => {
+      throw new Error('Access denied');
+    });
+    expect(loadTodos()).toEqual([]);
+  });
+
+  it('saveTodos does not throw if localStorage.setItem throws', () => {
+    localStorage.setItem = vi.fn(() => {
+      throw new Error('Quota exceeded');
+    });
+    expect(() => saveTodos([makeTodo()])).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #2

## Summary

Automated implementation of **Add localStorage persistence layer**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Verification | PASS |
| Details | 41 passed (41) |

## Code Review

### Findings Fixed
None — no issues found.

### Functional Completeness: PASS
All acceptance criteria met:
- `src/storage.js` exports `saveTodos`, `loadTodos`, `clearTodos`
- `saveTodos` writes to `localStorage` under key `todo-app-todos` using `JSON.stringify`
- `loadTodos` returns saved array or `[]` if nothing saved
- `loadTodos` returns `[]` for invalid JSON (tested with malformed string, number, object)
- `clearTodos` removes the key via `removeItem`
- Non-array valid JSON (e.g. `42`, `{}`) correctly returns `[]` (line 16: `Array.isArray` guard)

### Code Quality: PASS
- Defensive `try/catch` on all three functions — handles quota exceeded, private browsing, and access denied gracefully
- Clean functional style, no classes, follows project conventions
- `STORAGE_KEY` constant avoids magic strings
- No security concerns (no eval, no injection vectors)

### Test Coverage: PASS
- 11 tests covering: save, overwrite, load, round-trip, empty state, corrupt JSON, non-array JSON (number + object), localStorage throwing on both get and set
- Mock localStorage pattern is clean and idiomatic for Vitest

### Note on Included Files
The diff also includes `src/todo.js` and `tests/unit/todo.test.js` from issue #1 (dependency). These are correctly structured and all 29 todo tests pass. No concerns.

### Remaining Gaps
None.

### Verification Notes
- The `pnpm-lock.yaml` was added in this branch — this is expected for a greenfield project setting up dependencies for the first time.
- `storage.js` is not yet wired into `main.js` — this is correct since the issue scope is just the persistence layer. Integration will come in a later issue.

## Test Requirements

- Unit test `tests/unit/storage.test.js`
- Mock localStorage (use a simple object with getItem/setItem/removeItem)
- Test save/load round-trip
- Test loading with no data returns empty array
- Test loading with corrupt JSON returns empty array

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `sessions/`*