### PR TITLE
feat: Add drag-and-drop reordering of todos (closes #6)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { createTodo, toggleTodo, removeTodo, editTodo, filterTodos, countActive, countCompleted } from './todo.js';
+import { createTodo, toggleTodo, removeTodo, editTodo, reorderTodos, filterTodos, countActive, countCompleted } from './todo.js';
 import { loadTodos, saveTodos } from './storage.js';
 
 let todos = loadTodos();
@@ -48,6 +48,56 @@ function render() {
 
   const ul = document.createElement('ul');
   ul.setAttribute('data-testid', 'todo-list');
+
+  let draggedId = null;
+
+  ul.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const target = e.target.closest('.todo-item');
+    if (!target || !ul.contains(target)) return;
+    ul.querySelectorAll('.todo-item').forEach(el => {
+      el.classList.remove('drag-over-above', 'drag-over-below');
+    });
+    const rect = target.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    if (e.clientY < midY) {
+      target.classList.add('drag-over-above');
+    } else {
+      target.classList.add('drag-over-below');
+    }
+  });
+
+  ul.addEventListener('dragleave', (e) => {
+    const target = e.target.closest('.todo-item');
+    if (target) {
+      target.classList.remove('drag-over-above', 'drag-over-below');
+    }
+  });
+
+  ul.addEventListener('drop', (e) => {
+    e.preventDefault();
+    ul.querySelectorAll('.todo-item').forEach(el => {
+      el.classList.remove('drag-over-above', 'drag-over-below');
+    });
+    const target = e.target.closest('.todo-item');
+    if (!target || !draggedId) return;
+    const targetId = target.getAttribute('data-id');
+    if (draggedId === targetId) return;
+    const fromIndex = todos.findIndex(t => t.id === draggedId);
+    let toIndex = todos.findIndex(t => t.id === targetId);
+    if (fromIndex === -1 || toIndex === -1) return;
+    const rect = target.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    if (e.clientY >= midY && toIndex < fromIndex) {
+      toIndex++;
+    } else if (e.clientY < midY && toIndex > fromIndex) {
+      toIndex--;
+    }
+    todos = reorderTodos(todos, fromIndex, toIndex);
+    saveTodos(todos);
+    render();
+  });
 
   const visibleTodos = filterTodos(todos, currentFilter);
 
@@ -112,6 +162,25 @@ function render() {
         editInput.select();
       });
     } else {
+      li.draggable = true;
+
+      li.addEventListener('dragstart', (e) => {
+        draggedId = todo.id;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', todo.id);
+        li.classList.add('dragging');
+      });
+
+      li.addEventListener('dragend', () => {
+        li.classList.remove('dragging');
+        draggedId = null;
+      });
+
+      const handle = document.createElement('span');
+      handle.className = 'drag-handle';
+      handle.textContent = '\u2801\u2801\u2801';
+      handle.setAttribute('data-testid', 'drag-handle');
+
       const checkbox = document.createElement('input');
       checkbox.type = 'checkbox';
       checkbox.checked = todo.completed;
@@ -141,6 +210,7 @@ function render() {
         render();
       });
 
+      li.appendChild(handle);
       li.appendChild(checkbox);
       li.appendChild(span);
       li.appendChild(deleteBtn);

--- a/src/style.css
+++ b/src/style.css
@@ -113,6 +113,31 @@ ul {
   outline: none;
 }
 
+.drag-handle {
+  cursor: grab;
+  color: #555;
+  font-size: 1rem;
+  user-select: none;
+  padding: 0 0.25rem;
+  flex-shrink: 0;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.todo-item.dragging {
+  opacity: 0.4;
+}
+
+.todo-item.drag-over-above {
+  border-top: 2px solid #0f3460;
+}
+
+.todo-item.drag-over-below {
+  border-bottom: 2px solid #0f3460;
+}
+
 .delete-btn {
   background: none;
   border: none;

--- a/src/todo.js
+++ b/src/todo.js
@@ -31,6 +31,13 @@ export function editTodo(todos, id, newText) {
   );
 }
 
+export function reorderTodos(todos, fromIndex, toIndex) {
+  const result = [...todos];
+  const [moved] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, moved);
+  return result;
+}
+
 export function filterTodos(todos, filter) {
   if (filter === 'active') return todos.filter((t) => !t.completed);
   if (filter === 'completed') return todos.filter((t) => t.completed);

--- a/tests/e2e/reorder.spec.js
+++ b/tests/e2e/reorder.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+});
+
+test('drag first todo to last position and verify order', async ({ page }) => {
+  const items = ['First', 'Second', 'Third'];
+  for (const text of items) {
+    await page.getByTestId('todo-input').fill(text);
+    await page.getByTestId('add-button').click();
+  }
+
+  await expect(page.getByTestId('todo-item')).toHaveCount(3);
+
+  const firstHandle = page.getByTestId('drag-handle').first();
+  const lastItem = page.getByTestId('todo-item').last();
+
+  await firstHandle.dragTo(lastItem);
+
+  const texts = page.getByTestId('todo-text');
+  await expect(texts.nth(0)).toHaveText('Second');
+  await expect(texts.nth(1)).toHaveText('Third');
+  await expect(texts.nth(2)).toHaveText('First');
+});
+
+test('reorder persists after page refresh', async ({ page }) => {
+  const items = ['First', 'Second', 'Third'];
+  for (const text of items) {
+    await page.getByTestId('todo-input').fill(text);
+    await page.getByTestId('add-button').click();
+  }
+
+  const firstHandle = page.getByTestId('drag-handle').first();
+  const lastItem = page.getByTestId('todo-item').last();
+
+  await firstHandle.dragTo(lastItem);
+
+  await page.reload();
+
+  const texts = page.getByTestId('todo-text');
+  await expect(texts.nth(0)).toHaveText('Second');
+  await expect(texts.nth(1)).toHaveText('Third');
+  await expect(texts.nth(2)).toHaveText('First');
+});

--- a/tests/unit/todo.test.js
+++ b/tests/unit/todo.test.js
@@ -4,6 +4,7 @@ import {
   toggleTodo,
   removeTodo,
   editTodo,
+  reorderTodos,
   filterTodos,
   countActive,
   countCompleted,
@@ -137,6 +138,57 @@ describe('editTodo', () => {
     const todos = [makeTodo(), makeTodo({ id: 'test-2' })];
     const result = editTodo(todos, 'test-1', 'Updated');
     expect(result[1]).toBe(todos[1]);
+  });
+});
+
+describe('reorderTodos', () => {
+  it('moves item from first to last position', () => {
+    const todos = [
+      makeTodo({ id: '1', text: 'A' }),
+      makeTodo({ id: '2', text: 'B' }),
+      makeTodo({ id: '3', text: 'C' }),
+    ];
+    const result = reorderTodos(todos, 0, 2);
+    expect(result.map(t => t.id)).toEqual(['2', '3', '1']);
+  });
+
+  it('moves item from last to first position', () => {
+    const todos = [
+      makeTodo({ id: '1', text: 'A' }),
+      makeTodo({ id: '2', text: 'B' }),
+      makeTodo({ id: '3', text: 'C' }),
+    ];
+    const result = reorderTodos(todos, 2, 0);
+    expect(result.map(t => t.id)).toEqual(['3', '1', '2']);
+  });
+
+  it('does not mutate the original array', () => {
+    const todos = Object.freeze([
+      makeTodo({ id: '1' }),
+      makeTodo({ id: '2' }),
+      makeTodo({ id: '3' }),
+    ]);
+    const result = reorderTodos(todos, 0, 2);
+    expect(result).not.toBe(todos);
+    expect(todos.map(t => t.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('handles same index (no-op)', () => {
+    const todos = [
+      makeTodo({ id: '1' }),
+      makeTodo({ id: '2' }),
+    ];
+    const result = reorderTodos(todos, 1, 1);
+    expect(result.map(t => t.id)).toEqual(['1', '2']);
+  });
+
+  it('handles adjacent swap', () => {
+    const todos = [
+      makeTodo({ id: '1', text: 'A' }),
+      makeTodo({ id: '2', text: 'B' }),
+    ];
+    const result = reorderTodos(todos, 0, 1);
+    expect(result.map(t => t.id)).toEqual(['2', '1']);
   });
 });
 


### PR DESCRIPTION
Closes #6

## Summary

Automated implementation of **Add drag-and-drop reordering of todos**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Verification | PASS |
| Details | 46 passed (46) |

## Code Review

### Findings Fixed

None — no critical or warning-level issues found.

### Remaining Gaps

None — all acceptance criteria are implemented and tested.

### Verification Notes

- All 46 unit tests pass
- All 20 E2E tests pass (including 2 reorder-specific tests)
- Production build succeeds
- **Manual check recommended**: Try dragging with different filter views active (Active, Completed) to confirm reorder applies to underlying data as expected. The code logic is correct (reorder operates on `todos`, not `visibleTodos`), but the UX of dragging filtered items may be confusing since indices in the filtered view don't match indices in the full list — the implementation correctly maps back to the full `todos` array via `todo.id` lookup at `main.js:87-88`.
- **Manual check recommended**: Verify drag handle icon renders well across browsers (braille characters may vary in appearance).

## Test Requirements

- E2E test `tests/e2e/reorder.spec.js`:
  - Add 3 todos, drag first to last position, verify new order
  - Refresh page, verify order persisted
  - (Use Playwright's dragTo method)

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `sessions/`*