### PR TITLE
feat: Add priority levels (low, medium, high) with color coding (closes #8)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { createTodo, toggleTodo, removeTodo, editTodo, reorderTodos, filterTodos, countActive, countCompleted, isOverdue, isDueToday } from './todo.js';
+import { createTodo, toggleTodo, removeTodo, editTodo, reorderTodos, filterTodos, countActive, countCompleted, isOverdue, isDueToday, sortByPriority } from './todo.js';
 import { loadTodos, saveTodos } from './storage.js';
 
 let todos = loadTodos();
@@ -34,15 +34,26 @@ function render() {
   dateInput.type = 'date';
   dateInput.setAttribute('data-testid', 'due-date-input');
 
+  const prioritySelect = document.createElement('select');
+  prioritySelect.setAttribute('data-testid', 'priority-select');
+  for (const p of ['low', 'medium', 'high']) {
+    const opt = document.createElement('option');
+    opt.value = p;
+    opt.textContent = p.charAt(0).toUpperCase() + p.slice(1);
+    if (p === 'medium') opt.selected = true;
+    prioritySelect.appendChild(opt);
+  }
+
   form.appendChild(input);
   form.appendChild(dateInput);
+  form.appendChild(prioritySelect);
   form.appendChild(addBtn);
   container.appendChild(form);
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();
     try {
-      const todo = createTodo(input.value, dateInput.value || null);
+      const todo = createTodo(input.value, { dueDate: dateInput.value || null, priority: prioritySelect.value });
       todos = [...todos, todo];
       saveTodos(todos);
       render();
@@ -220,6 +231,12 @@ function render() {
         render();
       });
 
+      const priorityDot = document.createElement('span');
+      const todoPriority = todo.priority || 'medium';
+      priorityDot.className = `priority-indicator priority-${todoPriority}`;
+      priorityDot.setAttribute('data-testid', 'priority-indicator');
+
+      li.appendChild(priorityDot);
       li.appendChild(handle);
       li.appendChild(checkbox);
       li.appendChild(span);
@@ -274,6 +291,17 @@ function render() {
   }
 
   footer.appendChild(filterGroup);
+
+  const sortPriorityBtn = document.createElement('button');
+  sortPriorityBtn.textContent = 'Sort by priority';
+  sortPriorityBtn.setAttribute('data-testid', 'sort-priority');
+  sortPriorityBtn.className = 'sort-priority';
+  sortPriorityBtn.addEventListener('click', () => {
+    todos = sortByPriority(todos);
+    saveTodos(todos);
+    render();
+  });
+  footer.appendChild(sortPriorityBtn);
 
   if (countCompleted(todos) > 0) {
     const clearBtn = document.createElement('button');

--- a/src/style.css
+++ b/src/style.css
@@ -251,3 +251,48 @@ ul {
 .clear-completed:hover {
   color: #e74c3c;
 }
+
+.priority-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.priority-high {
+  background: #e74c3c;
+}
+
+.priority-medium {
+  background: #f39c12;
+}
+
+.priority-low {
+  background: #3498db;
+}
+
+.todo-form select {
+  padding: 0.75rem;
+  border: 1px solid #333;
+  border-radius: 6px;
+  background: #16213e;
+  color: #e0e0e0;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.sort-priority {
+  background: none;
+  border: 1px solid transparent;
+  color: #666;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.sort-priority:hover {
+  color: #e0e0e0;
+  border-color: #0f3460;
+}

--- a/src/todo.js
+++ b/src/todo.js
@@ -1,15 +1,30 @@
-export function createTodo(text, dueDate = null) {
+export function createTodo(text, options = {}) {
   const trimmed = text.trim();
   if (!trimmed) {
     throw new Error('Todo text cannot be empty');
   }
+  const { dueDate = null, priority = 'medium' } = options;
   return {
     id: Date.now().toString(36) + Math.random().toString(36).slice(2),
     text: trimmed,
     completed: false,
     createdAt: Date.now(),
     dueDate: dueDate || null,
+    priority,
   };
+}
+
+export function setPriority(todos, id, priority) {
+  return todos.map(todo =>
+    todo.id === id ? { ...todo, priority } : todo
+  );
+}
+
+export function sortByPriority(todos) {
+  const weight = { high: 0, medium: 1, low: 2 };
+  return [...todos].sort((a, b) =>
+    (weight[a.priority] ?? 1) - (weight[b.priority] ?? 1)
+  );
 }
 
 export function isOverdue(todo) {

--- a/tests/e2e/priority.spec.js
+++ b/tests/e2e/priority.spec.js
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+});
+
+test('default priority is medium with orange indicator', async ({ page }) => {
+  await page.getByTestId('todo-input').fill('Default priority todo');
+  await page.getByTestId('add-button').click();
+
+  const select = page.getByTestId('priority-select');
+  await expect(select).toHaveValue('medium');
+
+  const indicator = page.getByTestId('priority-indicator');
+  await expect(indicator).toHaveClass(/priority-medium/);
+});
+
+test('add todo with high priority shows red indicator', async ({ page }) => {
+  await page.getByTestId('priority-select').selectOption('high');
+  await page.getByTestId('todo-input').fill('Urgent task');
+  await page.getByTestId('add-button').click();
+
+  const indicator = page.getByTestId('priority-indicator');
+  await expect(indicator).toHaveClass(/priority-high/);
+});
+
+test('add todo with low priority shows blue indicator', async ({ page }) => {
+  await page.getByTestId('priority-select').selectOption('low');
+  await page.getByTestId('todo-input').fill('Someday task');
+  await page.getByTestId('add-button').click();
+
+  const indicator = page.getByTestId('priority-indicator');
+  await expect(indicator).toHaveClass(/priority-low/);
+});
+
+test('sort by priority orders high first', async ({ page }) => {
+  await page.getByTestId('priority-select').selectOption('low');
+  await page.getByTestId('todo-input').fill('Low task');
+  await page.getByTestId('add-button').click();
+
+  await page.getByTestId('priority-select').selectOption('high');
+  await page.getByTestId('todo-input').fill('High task');
+  await page.getByTestId('add-button').click();
+
+  await page.getByTestId('priority-select').selectOption('medium');
+  await page.getByTestId('todo-input').fill('Medium task');
+  await page.getByTestId('add-button').click();
+
+  await page.getByTestId('sort-priority').click();
+
+  const texts = page.getByTestId('todo-text');
+  await expect(texts.nth(0)).toHaveText('High task');
+  await expect(texts.nth(1)).toHaveText('Medium task');
+  await expect(texts.nth(2)).toHaveText('Low task');
+});
+
+test('priority persists after reload', async ({ page }) => {
+  await page.getByTestId('priority-select').selectOption('high');
+  await page.getByTestId('todo-input').fill('Persistent high');
+  await page.getByTestId('add-button').click();
+
+  await page.reload();
+
+  const indicator = page.getByTestId('priority-indicator');
+  await expect(indicator).toHaveClass(/priority-high/);
+});

--- a/tests/unit/todo.test.js
+++ b/tests/unit/todo.test.js
@@ -11,6 +11,8 @@ import {
   isOverdue,
   isDueToday,
   sortByDueDate,
+  setPriority,
+  sortByPriority,
 } from '../../src/todo.js';
 
 function makeTodo(overrides = {}) {
@@ -283,13 +285,93 @@ describe('countCompleted', () => {
 
 describe('createTodo with dueDate', () => {
   it('creates todo with dueDate when provided', () => {
-    const todo = createTodo('Test', '2026-04-15');
+    const todo = createTodo('Test', { dueDate: '2026-04-15' });
     expect(todo.dueDate).toBe('2026-04-15');
   });
 
   it('creates todo with null dueDate by default', () => {
     const todo = createTodo('Test');
     expect(todo.dueDate).toBeNull();
+  });
+});
+
+describe('createTodo with priority', () => {
+  it('defaults to medium priority', () => {
+    const todo = createTodo('Test');
+    expect(todo.priority).toBe('medium');
+  });
+
+  it('sets priority from options', () => {
+    const todo = createTodo('Test', { priority: 'high' });
+    expect(todo.priority).toBe('high');
+  });
+
+  it('sets both dueDate and priority', () => {
+    const todo = createTodo('Test', { dueDate: '2026-04-15', priority: 'low' });
+    expect(todo.dueDate).toBe('2026-04-15');
+    expect(todo.priority).toBe('low');
+  });
+});
+
+describe('setPriority', () => {
+  it('changes priority for matching ID', () => {
+    const todos = [makeTodo({ priority: 'medium' })];
+    const result = setPriority(todos, 'test-1', 'high');
+    expect(result[0].priority).toBe('high');
+  });
+
+  it('does not mutate the original array', () => {
+    const todos = Object.freeze([Object.freeze(makeTodo({ priority: 'medium' }))]);
+    const result = setPriority(todos, 'test-1', 'low');
+    expect(result).not.toBe(todos);
+    expect(result[0].priority).toBe('low');
+  });
+
+  it('leaves other todos unchanged', () => {
+    const todos = [makeTodo(), makeTodo({ id: 'test-2' })];
+    const result = setPriority(todos, 'test-1', 'high');
+    expect(result[1]).toBe(todos[1]);
+  });
+});
+
+describe('sortByPriority', () => {
+  it('sorts high first, then medium, then low', () => {
+    const todos = [
+      makeTodo({ id: '1', priority: 'low' }),
+      makeTodo({ id: '2', priority: 'high' }),
+      makeTodo({ id: '3', priority: 'medium' }),
+    ];
+    const result = sortByPriority(todos);
+    expect(result.map(t => t.id)).toEqual(['2', '3', '1']);
+  });
+
+  it('handles missing priority as medium', () => {
+    const todos = [
+      makeTodo({ id: '1', priority: 'low' }),
+      makeTodo({ id: '2' }), // no priority field
+    ];
+    delete todos[1].priority;
+    const result = sortByPriority(todos);
+    expect(result.map(t => t.id)).toEqual(['2', '1']);
+  });
+
+  it('does not mutate input', () => {
+    const todos = Object.freeze([
+      makeTodo({ id: '1', priority: 'low' }),
+      makeTodo({ id: '2', priority: 'high' }),
+    ]);
+    const result = sortByPriority(todos);
+    expect(result).not.toBe(todos);
+    expect(todos[0].id).toBe('1');
+  });
+
+  it('preserves order for same priority', () => {
+    const todos = [
+      makeTodo({ id: '1', priority: 'medium' }),
+      makeTodo({ id: '2', priority: 'medium' }),
+    ];
+    const result = sortByPriority(todos);
+    expect(result.map(t => t.id)).toEqual(['1', '2']);
   });
 });
 


### PR DESCRIPTION
Closes #8

## Summary

Automated implementation of **Add priority levels (low, medium, high) with color coding**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Verification | PASS |
| Details | 73 passed (73) |

## Code Review

### Findings Fixed

None needed - the implementation is complete and correct.

### Remaining Gaps

- **`setPriority` not wired to UI**: The function exists and is unit-tested, but there's no way for users to change a todo's priority after creation. The issue spec says `setPriority(todos, id, priority) → new todos array` which is implemented. It wasn't listed as an acceptance criterion for the UI, so this is informational only.
- **No priority validation**: `setPriority` and `createTodo` accept any string for priority (e.g., `'critical'`). Low risk since the only caller is the controlled `<select>`, but worth noting.

### Verification Notes

- All unit tests pass (73/73)
- All E2E tests pass (31/31)
- Build succeeds cleanly
- Code follows project conventions: pure functions in `todo.js`, DOM in `main.js`, CSS in `style.css`
- Dark mode colors look intentional (red/orange/blue dots on dark background)
- Priority dot is rendered as first child of `li`, giving good visual hierarchy
- The `pnpm-lock.yaml` addition is notable - the project may have been using npm previously (there may be a `package-lock.json` on main). Not a blocker for this PR.

### Overall Assessment

Clean, complete implementation. All acceptance criteria met, all required tests present and passing. The code maintains the established architectural boundaries and follows the functional style.

## Test Requirements

- Unit test: `setPriority` and `sortByPriority`
- E2E test `tests/e2e/priority.spec.js`:
  - Add todos with different priorities
  - Verify color coding
  - Sort by priority and verify order

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `sessions/`*