### PR TITLE
feat: Add keyboard shortcuts and accessibility (closes #9)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { createTodo, toggleTodo, removeTodo, editTodo, reorderTodos, filterTodos, countActive, countCompleted, isOverdue, isDueToday, sortByPriority } from './todo.js';
+import { createTodo, toggleTodo, removeTodo, editTodo, reorderTodos, filterTodos, countActive, countCompleted, isOverdue, isDueToday, sortByPriority, toggleAllTodos } from './todo.js';
 import { loadTodos, saveTodos } from './storage.js';
 
 let todos = loadTodos();
@@ -6,6 +6,108 @@ let currentFilter = 'all';
 let editingId = null;
 
 const app = document.getElementById('app');
+
+// Live region for screen reader announcements
+const liveRegion = document.createElement('div');
+liveRegion.setAttribute('aria-live', 'polite');
+liveRegion.setAttribute('id', 'live-region');
+liveRegion.className = 'sr-only';
+document.body.appendChild(liveRegion);
+
+function announce(message) {
+  liveRegion.textContent = message;
+}
+
+// Shortcuts help overlay
+const shortcutsOverlay = document.createElement('div');
+shortcutsOverlay.className = 'shortcuts-overlay hidden';
+shortcutsOverlay.setAttribute('data-testid', 'shortcuts-help');
+shortcutsOverlay.innerHTML = `
+  <div class="shortcuts-content">
+    <h2>Keyboard Shortcuts</h2>
+    <dl class="shortcuts-list">
+      <div><dt>/</dt><dd>Focus input</dd></div>
+      <div><dt>1</dt><dd>Show All</dd></div>
+      <div><dt>2</dt><dd>Show Active</dd></div>
+      <div><dt>3</dt><dd>Show Completed</dd></div>
+      <div><dt>Ctrl/⌘+A</dt><dd>Toggle all todos</dd></div>
+      <div><dt>?</dt><dd>Toggle this help</dd></div>
+    </dl>
+    <p class="shortcuts-dismiss">Press <kbd>Esc</kbd> or <kbd>?</kbd> to close</p>
+  </div>
+`;
+document.body.appendChild(shortcutsOverlay);
+
+shortcutsOverlay.addEventListener('click', (e) => {
+  if (e.target === shortcutsOverlay) {
+    shortcutsOverlay.classList.add('hidden');
+  }
+});
+
+// Shortcuts trigger button
+const shortcutsTrigger = document.createElement('button');
+shortcutsTrigger.className = 'shortcuts-trigger';
+shortcutsTrigger.setAttribute('data-testid', 'shortcuts-trigger');
+shortcutsTrigger.setAttribute('aria-label', 'Show keyboard shortcuts');
+shortcutsTrigger.textContent = '?';
+shortcutsTrigger.addEventListener('click', () => {
+  shortcutsOverlay.classList.toggle('hidden');
+});
+document.body.appendChild(shortcutsTrigger);
+
+// Global keyboard shortcuts
+document.addEventListener('keydown', (e) => {
+  const tag = document.activeElement?.tagName;
+  const inputFocused = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+  const overlayVisible = !shortcutsOverlay.classList.contains('hidden');
+
+  if (e.key === 'Escape' && overlayVisible) {
+    shortcutsOverlay.classList.add('hidden');
+    return;
+  }
+
+  if (e.key === '?' && !inputFocused) {
+    shortcutsOverlay.classList.toggle('hidden');
+    return;
+  }
+
+  // Disable other shortcuts while overlay is visible
+  if (overlayVisible) return;
+
+  if (e.key === '/') {
+    e.preventDefault();
+    const todoInput = document.querySelector('[data-testid="todo-input"]');
+    if (todoInput) todoInput.focus();
+    return;
+  }
+
+  if (!inputFocused) {
+    if (e.key === '1') {
+      currentFilter = 'all';
+      render();
+      return;
+    }
+    if (e.key === '2') {
+      currentFilter = 'active';
+      render();
+      return;
+    }
+    if (e.key === '3') {
+      currentFilter = 'completed';
+      render();
+      return;
+    }
+    if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+      e.preventDefault();
+      todos = toggleAllTodos(todos);
+      saveTodos(todos);
+      render();
+      const allCompleted = todos.every(t => t.completed);
+      announce(allCompleted ? 'All todos completed' : 'All todos marked active');
+      return;
+    }
+  }
+});
 
 function render() {
   app.innerHTML = '';
@@ -57,6 +159,7 @@ function render() {
       todos = [...todos, todo];
       saveTodos(todos);
       render();
+      announce('Todo added');
     } catch {
       // Empty input — ignore
     }
@@ -64,6 +167,7 @@ function render() {
 
   const ul = document.createElement('ul');
   ul.setAttribute('data-testid', 'todo-list');
+  ul.setAttribute('role', 'list');
 
   let draggedId = null;
 
@@ -126,6 +230,7 @@ function render() {
     li.className = className;
     li.setAttribute('data-testid', 'todo-item');
     li.setAttribute('data-id', todo.id);
+    li.setAttribute('role', 'listitem');
     if (isOverdue(todo)) li.setAttribute('data-overdue', '');
 
     if (editingId === todo.id) {
@@ -206,10 +311,13 @@ function render() {
       checkbox.type = 'checkbox';
       checkbox.checked = todo.completed;
       checkbox.setAttribute('data-testid', 'todo-checkbox');
+      checkbox.setAttribute('aria-label', `Mark ${todo.text} as ${todo.completed ? 'incomplete' : 'complete'}`);
       checkbox.addEventListener('change', () => {
         todos = toggleTodo(todos, todo.id);
         saveTodos(todos);
         render();
+        const toggled = todos.find(t => t.id === todo.id);
+        announce(toggled?.completed ? 'Todo completed' : 'Todo marked active');
       });
 
       const span = document.createElement('span');
@@ -225,10 +333,12 @@ function render() {
       deleteBtn.className = 'delete-btn';
       deleteBtn.innerHTML = '&times;';
       deleteBtn.setAttribute('data-testid', 'todo-delete');
+      deleteBtn.setAttribute('aria-label', `Delete ${todo.text}`);
       deleteBtn.addEventListener('click', () => {
         todos = removeTodo(todos, todo.id);
         saveTodos(todos);
         render();
+        announce('Todo deleted');
       });
 
       const priorityDot = document.createElement('span');
@@ -282,6 +392,7 @@ function render() {
     const btn = document.createElement('button');
     btn.textContent = filter.charAt(0).toUpperCase() + filter.slice(1);
     btn.setAttribute('data-testid', `filter-${filter}`);
+    btn.setAttribute('aria-pressed', String(filter === currentFilter));
     if (filter === currentFilter) btn.classList.add('active');
     btn.addEventListener('click', () => {
       currentFilter = filter;
@@ -312,6 +423,7 @@ function render() {
       todos = todos.filter(t => !t.completed);
       saveTodos(todos);
       render();
+      announce('Completed todos cleared');
     });
     footer.appendChild(clearBtn);
   }

--- a/src/style.css
+++ b/src/style.css
@@ -296,3 +296,123 @@ ul {
   color: #e0e0e0;
   border-color: #0f3460;
 }
+
+/* Focus styles for keyboard navigation */
+:focus-visible {
+  outline: 2px solid #0f3460;
+  outline-offset: 2px;
+}
+
+.delete-btn:focus-visible {
+  opacity: 1;
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Shortcuts trigger button */
+.shortcuts-trigger {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #333;
+  background: #16213e;
+  color: #888;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, border-color 0.15s;
+  z-index: 100;
+}
+
+.shortcuts-trigger:hover {
+  color: #e0e0e0;
+  border-color: #0f3460;
+}
+
+/* Shortcuts overlay */
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.shortcuts-overlay.hidden {
+  display: none;
+}
+
+.shortcuts-content {
+  background: #16213e;
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 2rem;
+  max-width: 360px;
+  width: 90%;
+}
+
+.shortcuts-content h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 1rem;
+}
+
+.shortcuts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shortcuts-list > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.shortcuts-list dt {
+  background: #1a1a2e;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  color: #e0e0e0;
+  font-family: monospace;
+}
+
+.shortcuts-list dd {
+  color: #888;
+  font-size: 0.875rem;
+}
+
+.shortcuts-dismiss {
+  margin-top: 1rem;
+  text-align: center;
+  color: #555;
+  font-size: 0.75rem;
+}
+
+.shortcuts-dismiss kbd {
+  background: #1a1a2e;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.7rem;
+}

--- a/src/todo.js
+++ b/src/todo.js
@@ -93,3 +93,9 @@ export function countActive(todos) {
 export function countCompleted(todos) {
   return todos.filter((t) => t.completed).length;
 }
+
+export function toggleAllTodos(todos) {
+  if (todos.length === 0) return todos;
+  const allCompleted = todos.every(t => t.completed);
+  return todos.map(t => ({ ...t, completed: !allCompleted }));
+}

--- a/tests/e2e/keyboard.spec.js
+++ b/tests/e2e/keyboard.spec.js
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Keyboard shortcuts and accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  test('/ focuses the input', async ({ page }) => {
+    await page.keyboard.press('/');
+    await expect(page.getByTestId('todo-input')).toBeFocused();
+  });
+
+  test('1, 2, 3 switch filters', async ({ page }) => {
+    // Add a todo and complete it so filters have something to show
+    await page.getByTestId('todo-input').fill('Test todo');
+    await page.getByTestId('add-button').click();
+    await page.getByTestId('todo-checkbox').click();
+
+    // Click somewhere neutral to blur input
+    await page.locator('h1').click();
+
+    await page.keyboard.press('2'); // Active
+    await expect(page.getByTestId('filter-active')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('filter-all')).toHaveAttribute('aria-pressed', 'false');
+
+    await page.keyboard.press('3'); // Completed
+    await expect(page.getByTestId('filter-completed')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.keyboard.press('1'); // All
+    await expect(page.getByTestId('filter-all')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('filter shortcuts ignored when input focused', async ({ page }) => {
+    await page.getByTestId('todo-input').focus();
+    await page.keyboard.press('2');
+    // Filter should NOT have changed
+    await expect(page.getByTestId('filter-all')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('Tab navigates through interactive elements', async ({ page }) => {
+    // Add a todo
+    await page.getByTestId('todo-input').fill('Buy milk');
+    await page.getByTestId('add-button').click();
+
+    // Start from the add button (reliable starting point)
+    await page.getByTestId('add-button').focus();
+
+    // Tab from add button → should reach the checkbox
+    await page.keyboard.press('Tab');
+    await expect(page.getByTestId('todo-checkbox')).toBeFocused();
+
+    // Verify checkbox is keyboard-accessible
+    const checkbox = page.getByTestId('todo-checkbox');
+    await expect(checkbox).toHaveAttribute('aria-label', /Buy milk/);
+  });
+
+  test('checkboxes have aria-labels', async ({ page }) => {
+    await page.getByTestId('todo-input').fill('Buy milk');
+    await page.getByTestId('add-button').click();
+
+    const checkbox = page.getByTestId('todo-checkbox');
+    await expect(checkbox).toHaveAttribute('aria-label', 'Mark Buy milk as complete');
+  });
+
+  test('delete buttons have aria-labels', async ({ page }) => {
+    await page.getByTestId('todo-input').fill('Buy milk');
+    await page.getByTestId('add-button').click();
+
+    const deleteBtn = page.getByTestId('todo-delete');
+    await expect(deleteBtn).toHaveAttribute('aria-label', 'Delete Buy milk');
+  });
+
+  test('filter buttons have aria-pressed', async ({ page }) => {
+    await expect(page.getByTestId('filter-all')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('filter-active')).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.getByTestId('filter-completed')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('todo list has role="list" and items have role="listitem"', async ({ page }) => {
+    await page.getByTestId('todo-input').fill('Test item');
+    await page.getByTestId('add-button').click();
+
+    await expect(page.getByTestId('todo-list')).toHaveAttribute('role', 'list');
+    await expect(page.getByTestId('todo-item')).toHaveAttribute('role', 'listitem');
+  });
+
+  test('live region announces todo changes', async ({ page }) => {
+    // Add a todo
+    await page.getByTestId('todo-input').fill('Test todo');
+    await page.getByTestId('add-button').click();
+    await expect(page.locator('#live-region')).toHaveText('Todo added');
+
+    // Complete it
+    await page.getByTestId('todo-checkbox').click();
+    await expect(page.locator('#live-region')).toHaveText('Todo completed');
+
+    // Delete it
+    await page.getByTestId('todo-delete').click();
+    await expect(page.locator('#live-region')).toHaveText('Todo deleted');
+  });
+
+  test('? button opens shortcuts overlay', async ({ page }) => {
+    await expect(page.getByTestId('shortcuts-help')).not.toBeVisible();
+    await page.getByTestId('shortcuts-trigger').click();
+    await expect(page.getByTestId('shortcuts-help')).toBeVisible();
+  });
+
+  test('Escape closes shortcuts overlay', async ({ page }) => {
+    await page.getByTestId('shortcuts-trigger').click();
+    await expect(page.getByTestId('shortcuts-help')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('shortcuts-help')).not.toBeVisible();
+  });
+
+  test('? key toggles shortcuts overlay', async ({ page }) => {
+    await page.locator('h1').click(); // Ensure no input focused
+    await page.keyboard.press('?');
+    await expect(page.getByTestId('shortcuts-help')).toBeVisible();
+    await page.keyboard.press('?');
+    await expect(page.getByTestId('shortcuts-help')).not.toBeVisible();
+  });
+
+  test('delete button visible on focus', async ({ page }) => {
+    await page.getByTestId('todo-input').fill('Test');
+    await page.getByTestId('add-button').click();
+
+    const deleteBtn = page.getByTestId('todo-delete');
+    await deleteBtn.focus();
+    await expect(deleteBtn).toBeVisible();
+  });
+});

--- a/tests/unit/todo.test.js
+++ b/tests/unit/todo.test.js
@@ -13,6 +13,7 @@ import {
   sortByDueDate,
   setPriority,
   sortByPriority,
+  toggleAllTodos,
 } from '../../src/todo.js';
 
 function makeTodo(overrides = {}) {
@@ -465,5 +466,38 @@ describe('sortByDueDate', () => {
     const result = sortByDueDate(todos);
     expect(result).not.toBe(todos);
     expect(todos[0].id).toBe('1');
+  });
+});
+
+describe('toggleAllTodos', () => {
+  it('marks all as completed when some are active', () => {
+    const todos = [
+      makeTodo({ id: '1', completed: false }),
+      makeTodo({ id: '2', completed: true }),
+      makeTodo({ id: '3', completed: false }),
+    ];
+    const result = toggleAllTodos(todos);
+    expect(result.every(t => t.completed)).toBe(true);
+  });
+
+  it('marks all as active when all are completed', () => {
+    const todos = [
+      makeTodo({ id: '1', completed: true }),
+      makeTodo({ id: '2', completed: true }),
+    ];
+    const result = toggleAllTodos(todos);
+    expect(result.every(t => !t.completed)).toBe(true);
+  });
+
+  it('returns empty array unchanged', () => {
+    const result = toggleAllTodos([]);
+    expect(result).toEqual([]);
+  });
+
+  it('does not mutate the original array', () => {
+    const todos = [makeTodo({ id: '1', completed: false })];
+    const result = toggleAllTodos(todos);
+    expect(result).not.toBe(todos);
+    expect(todos[0].completed).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #9

## Summary

Automated implementation of **Add keyboard shortcuts and accessibility**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Verification | PASS |
| Details | 77 passed (77) |

## Code Review

### Findings Fixed

None — no critical or warning-level issues found.

### Code Quality Notes

- **Architecture**: Clean separation maintained — keyboard handlers and ARIA attributes in `main.js`, `toggleAllTodos` pure function in `todo.js`, styles in `style.css`. Follows project conventions.
- **Security**: No injection vectors. All content is set via `textContent` or DOM APIs, not `innerHTML` (except the static shortcuts overlay template which contains no user data).
- **Accessibility**: Thorough — live region for screen reader announcements, proper ARIA labels, `aria-pressed` on filter buttons, `:focus-visible` styles, delete button becomes visible on focus (`.delete-btn:focus-visible { opacity: 1 }`).
- **UX**: Shortcuts overlay is dismissible via Escape, clicking outside, or pressing `?` again. The `?` trigger is unobtrusive in the bottom-right corner. Shortcuts are disabled while the overlay is visible to prevent accidental actions.

### Remaining Gaps

- **Ctrl/Cmd+A has no E2E test** — the implementation exists and the `toggleAllTodos` function has unit tests, but no E2E test verifies the keyboard shortcut end-to-end. This is minor since the unit test covers the logic and the keyboard handler is simple.

### Verification Notes

- Manually verify the shortcuts overlay looks correct on the dark theme
- Verify Tab order feels natural with multiple todos (form inputs → first todo's checkbox → delete → next todo → ... → footer buttons)
- Test `Ctrl+A` / `Cmd+A` shortcut in a real browser (Playwright modifiers can be tricky to test reliably)

## Test Requirements

- E2E test `tests/e2e/keyboard.spec.js`:
  - Press `/` to focus input
  - Press `1`, `2`, `3` to switch filters
  - Tab through elements and verify focus order
  - Verify aria-labels on checkboxes and delete buttons

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `sessions/`*